### PR TITLE
fixes #45

### DIFF
--- a/src/components/about/Info.tsx
+++ b/src/components/about/Info.tsx
@@ -1,6 +1,6 @@
 const Info = (props: { info: string }) => {
   return (
-    <div className="text-ridesucr-white lgbackdrop-blur-lg flex h-full w-full items-center justify-center rounded-md bg-white/30 p-6 text-center text-base leading-6 sm:text-2xl sm:leading-7 md:text-3xl md:leading-8 lg:text-4xl lg:leading-[1.6]">
+    <div className="text-ridesucr-white flex h-full w-full items-center justify-center bg-white/30 p-4 text-center text-2xl leading-6 md:text-3xl md:leading-8 lg:rounded-md lg:p-6 lg:text-4xl lg:leading-[1.6]">
       <div className="">{props.info}</div>
     </div>
   );

--- a/src/components/about/InfoSection.tsx
+++ b/src/components/about/InfoSection.tsx
@@ -6,7 +6,7 @@ import car6 from "@/public/cars/car6.webp";
 const InfoSection = () => {
   return (
     <div className="flex w-full justify-center px-4 pb-10">
-      <div className="lg:backdrop-blur-0 w-full overflow-hidden rounded-2xl border border-white/20 bg-white/10 md:w-5/6 lg:w-2/3 lg:rounded-none lg:border-0 lg:bg-transparent">
+      <div className="w-full overflow-hidden rounded-2xl border border-white/20 bg-white/10 md:w-5/6 lg:w-2/3 lg:rounded-none lg:border-0 lg:bg-transparent">
         <div className="flex flex-col lg:hidden">
           <Info info="Rides @ UCR is a student-led club that aims to bring the car community together. We organize weekly events, such as car meets, with the purpose of fostering a community of enthusiasts." />
 
@@ -36,7 +36,7 @@ const InfoSection = () => {
             </div>
 
             <div className="relative">
-              <div className="absolute top-0 left-1/2 h-full w-[1px] -translate-x-1/2 bg-gradient-to-b from-transparent via-white to-transparent opacity-40" />
+              <div className="absolute left-1/2 h-full w-[1px] -translate-x-1/2 bg-gradient-to-b from-transparent via-white to-transparent opacity-40" />
             </div>
 
             <div className="flex flex-1 flex-col gap-4">


### PR DESCRIPTION
<img width="1470" height="834" alt="Screenshot 2026-02-27 at 5 12 20 PM" src="https://github.com/user-attachments/assets/ba41c65d-6f30-42d9-ae53-931a06f1dc3c" />
made the info display different when it is sm, md, and lg and the text smaller based on size